### PR TITLE
add capability to easily update the bridge(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,34 @@ The playbook uses the official docker container available from the Tor gitlab an
 ## Run the bridge
 
 In case your provider does not support pre-distribution of ssh keys and only offers you an initial ssh-root-password use something like this which asks for the root password to push the ssh-keys configured above and subsequently deactivate root password login:
-```
+
+```shell
 ansible-playbook -k -i <YOUR IP OR INVENTORY>, --extra-vars "ansible_user=root" init.yml
 ```
+
 Afterwards the setup is creating the docker container and boots up the bridge. 
 
 And yes, root is used for the kick-off process. As the container uses secure privilege seperation this seems to be an acceptable risk, espacialy for an instant bridge which should disappear after some time to rotate the IP. Of course you should secure your private ssh key with a password to keep the access to the server as tight as possible. 
 
+## Update the bridge
+
+For now you should manually monitor the [`docker-obfs4-bridge`](https://gitlab.torproject.org/tpo/anti-censorship/docker-obfs4-bridge) Gitlab for updates. If there are any, you can quickly update your instances by issuing the following command (or similar according to your inventory)
+
+```shell
+ansible-playbook init.yml \ 
+  -k -i <HOSTS TO UPDATE>, \ 
+  --extra-vars "ansible_user=root" \
+  --tags "update,tor"
+```
+
 ## Post-Snap
 
 The bridge needs some time to ramp up, check its availability etc. Afterwards you should be able to create a valid bridgeline using 
+
+```shell
+ docker exec \ 
+  $(docker ps --quiet --filter "name=docker-obfs4-bridge-obfs4-bridge-1") \ 
+  get-bridge-line
 ```
-docker exec CONTAINER_ID get-bridge-line
-```
+
 Also consult this for more information post installation infos: https://community.torproject.org/relay/setup/bridge/post-install/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Tor OBFS4 Bridge Ansible Playbook
 
-This is a quick-n-dirty ansible playbook to setup OBFS4 Tor bridges within a docker container. This way it is easy to deploy and destroy bridges on the go to circumvent blocking mechanisms based on bridge IPs as seen in russia by rotating bridge IPs. 
+This is a quick-n-dirty ansible playbook to setup OBFS4 Tor bridges within a docker container. This way it is easy to deploy and destroy bridges on the go to circumvent blocking mechanisms based on bridge IPs as seen in russia by rotating bridge IPs.
 
-The playbook uses the official docker container available from the Tor gitlab and works on Debian and Ubuntu. 
-
+The playbook uses the official docker container available from the Tor gitlab and works on Debian and Ubuntu.
 
 ## Preparation
 
-* clone repo
-* optional: create ansible inventory if deploying to multiple hosts at once
-* edit env file in _files/configs_. Add at least a correct contact e-mail, other changes are optional. See https://community.torproject.org/relay/setup/bridge/docker/ for details
-* Add ssh-pubkey files to _files/admin_pubkeys_
+- clone repo
+- optional: create ansible inventory if deploying to multiple hosts at once
+- edit env file in _files/configs_. Add at least a correct contact e-mail, other changes are optional. See https://community.torproject.org/relay/setup/bridge/docker/ for details
+- Add ssh-pubkey files to _files/admin_pubkeys_
 
 ## Run the bridge
 
@@ -20,28 +19,28 @@ In case your provider does not support pre-distribution of ssh keys and only off
 ansible-playbook -k -i <YOUR IP OR INVENTORY>, --extra-vars "ansible_user=root" init.yml
 ```
 
-Afterwards the setup is creating the docker container and boots up the bridge. 
+Afterwards the setup is creating the docker container and boots up the bridge.
 
-And yes, root is used for the kick-off process. As the container uses secure privilege seperation this seems to be an acceptable risk, espacialy for an instant bridge which should disappear after some time to rotate the IP. Of course you should secure your private ssh key with a password to keep the access to the server as tight as possible. 
+And true, root is used for the kick-off process. As the container uses secure privilege seperation this seems to be an acceptable risk, espacialy for an instant bridge which should disappear after some time to rotate the IP. Of course you should secure your private ssh key with a password to keep the access to the server as tight as possible.
 
 ## Update the bridge
 
 For now you should manually monitor the [`docker-obfs4-bridge`](https://gitlab.torproject.org/tpo/anti-censorship/docker-obfs4-bridge) Gitlab for updates. If there are any, you can quickly update your instances by issuing the following command (or similar according to your inventory)
 
 ```shell
-ansible-playbook init.yml \ 
-  -k -i <HOSTS TO UPDATE>, \ 
+ansible-playbook init.yml \
+  -k -i <HOSTS TO UPDATE>, \
   --extra-vars "ansible_user=root" \
   --tags "update,tor"
 ```
 
 ## Post-Snap
 
-The bridge needs some time to ramp up, check its availability etc. Afterwards you should be able to create a valid bridgeline using 
+The bridge needs some time to ramp up, check its availability etc. Afterwards you should be able to create a valid bridgeline using
 
 ```shell
- docker exec \ 
-  $(docker ps --quiet --filter "name=docker-obfs4-bridge-obfs4-bridge-1") \ 
+ docker exec \
+  $(docker ps --quiet --filter "name=docker-obfs4-bridge-obfs4-bridge-1") \
   get-bridge-line
 ```
 

--- a/configure-firewall.yml
+++ b/configure-firewall.yml
@@ -1,14 +1,17 @@
-- name: configure-firewall
+- name: Configure-firewall
   become: true
   hosts: all
   tasks:
     - name: Backup and "flush" iptables rules files
-      shell: |
+      ansible.builtin.shell: |
         mv -nv /etc/iptables/rules.v{4,6} /root/
         touch /etc/iptables/rules.v{4,6}
         chmod 644 /etc/iptables/rules.v{4,6}
+      register: result
       args:
         executable: /bin/bash
       tags:
         - firewall
         - backup
+      changed_when:
+        - result.rc == 0

--- a/docker-install.yml
+++ b/docker-install.yml
@@ -1,10 +1,13 @@
-- name: docker-install
+- name: Docker-install
   become: true
   hosts: all
   tasks:
     # Check for unattended-upgrades and kill it
     - name: Killing unattended-upgrades if any
-      shell: pkill -f unattended -e
+      ansible.builtin.command: pkill -f unattended -e
+      register: result
+      changed_when:
+        - result.rc == 0
       ignore_errors: true
 
     - name: Install required system packages
@@ -15,36 +18,36 @@
           - curl
           - software-properties-common
           - python3-pip
-        state: latest
+        state: present
         update_cache: true
       register: apt_action
       retries: 100
       until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
-    - name: install 'Docker SDK for Python'
-      pip:
+    - name: Install 'Docker SDK for Python'
+      ansible.builtin.pip:
         name: docker
     - name: Add Docker GPG apt Key
-      apt_key:
+      ansible.builtin.apt_key:
         url: https://download.docker.com/linux/debian/gpg
         state: present
 
     - name: Add Docker Repository
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: deb https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} stable
         state: present
-  
+
     - name: Update apt and install docker-ce
       ansible.builtin.apt:
-        pkg: 
+        pkg:
           - docker-ce
-        state: latest
+        state: present
         update_cache: true
       register: apt_action
       retries: 100
       until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
-    - name: Install docker-compose  
-      get_url: 
-        url : https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-{{ ansible_architecture }}
+    - name: Install docker-compose
+      ansible.builtin.get_url:
+        url: https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-{{ ansible_architecture }}
         dest: /usr/local/bin/docker-compose
-        mode: 'u+x,g+x'
+        mode: "u+x,g+x"

--- a/init.yml
+++ b/init.yml
@@ -1,35 +1,38 @@
 # initial configuration
-- name: init
-  become: yes
+- name: Init
+  become: true
   hosts: all
   tasks:
     - name: Set up authorized keys for root
-      authorized_key:
+      ansible.posix.authorized_key:
         user: root
         state: present
         key: "{{ lookup('file', item) }}"
-      with_fileglob: 
+      with_fileglob:
         - files/admin_pubkeys/*.pub
     - name: Disable password login
-      lineinfile: dest=/etc/ssh/sshd_config regexp="^PasswordAuthentication" line="PasswordAuthentication no" state=present
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: ^PasswordAuthentication
+        line: PasswordAuthentication no
+        state: present
     # Check for unattended-upgrades and kill it
     - name: Killing unattended-upgrades if present
-      shell: pkill -f unattended -e
+      ansible.builtin.command: pkill -f unattended -e
+      register: result
+      changed_when:
+        - result == 0
       ignore_errors: true
-    #- name: install dmidecode
-      #apt:
-      #  name: dmidecode
-      #  update_cache: yes
-    - name: update package cache
-      apt:
-        update_cache: yes
-    - name: upgrade packages
-      apt:
+    - name: Update package cache
+      ansible.builtin.apt:
+        update_cache: true
+    - name: Upgrade packages
+      ansible.builtin.apt:
         upgrade: dist
-        force: yes
-    - name: autoremove dependencies
-      apt:
-        autoremove: yes
+        force: true
+    - name: Autoremove dependencies
+      ansible.builtin.apt:
+        autoremove: true
 
 - name: Install docker stuff
   import_playbook: docker-install.yml
@@ -37,13 +40,13 @@
 - name: Configure iptables firewall
   import_playbook: configure-firewall.yml
 
-  #reboot
+  # reboot
 - name: Reboot after install is done
-  become: yes
+  become: true
   hosts: all
-  tasks: 
+  tasks:
     - name: Rebooting Machine...
-      reboot:
+      ansible.builtin.reboot:
 
 - name: Install and run bridge container
-  import_playbook: run_bridge.yml
+  ansible.builtin.import_playbook: run_bridge.yml

--- a/run_bridge.yml
+++ b/run_bridge.yml
@@ -8,20 +8,50 @@
        dest: /root/docker-obfs4-bridge
        clone: yes
        update: yes
+       force: yes
+      tags:
+        - update
+        - tor
     - name: Copy .env file
       copy:
         src: configs/env
         dest: /root/docker-obfs4-bridge/.env
+      tags:
+        - update
+        - tor
     - name: switch to Docker build on ARM Architecture
       shell: |
         sed -i.bak "s#FROM debian:stable-slim#FROM arm64v8/debian:stable-slim#" /root/docker-obfs4-bridge/Dockerfile
         sed -i.bak "s#image: thetorproject/obfs4-bridge:latest#build: .#" /root/docker-obfs4-bridge/docker-compose.yml
       when: ansible_architecture == "aarch64"
+      tags:
+        - update
+        - tor
+    - name: Build docker-compose project
+      command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml build
+      when: ansible_architecture == "aarch64"
+      tags:
+        - update
+        - tor
+    - name: Pull new docker image
+      command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml pull
+      when: ansible_architecture == "x86_64"
+      tags:
+        - update
+        - tor
     - name: Starting container
       command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml up -d
       register: out
+      tags:
+        - update
+        - tor
     - name: Retrieving first run logs
       command: docker container logs docker-obfs4-bridge-obfs4-bridge-1
       register: out
-
+      tags:
+        - update
+        - tor
     - debug: var=out.stdout_lines
+      tags:
+        - update
+        - tor

--- a/run_bridge.yml
+++ b/run_bridge.yml
@@ -1,57 +1,87 @@
-- name: run_bridge
+- name: Run_bridge
   become: true
   hosts: all
   tasks:
     - name: Clone container repo
-      git:
-       repo: https://gitlab.torproject.org/tpo/anti-censorship/docker-obfs4-bridge.git
-       dest: /root/docker-obfs4-bridge
-       clone: yes
-       update: yes
-       force: yes
+      ansible.builtin.git:
+        repo: https://gitlab.torproject.org/tpo/anti-censorship/docker-obfs4-bridge.git
+        version: "v0.11"
+        dest: /root/docker-obfs4-bridge
+        clone: true
+        update: true
+        force: true
       tags:
         - update
         - tor
     - name: Copy .env file
-      copy:
+      ansible.builtin.copy:
         src: configs/env
         dest: /root/docker-obfs4-bridge/.env
+        mode: 0600
       tags:
         - update
         - tor
-    - name: switch to Docker build on ARM Architecture
-      shell: |
-        sed -i.bak "s#FROM debian:stable-slim#FROM arm64v8/debian:stable-slim#" /root/docker-obfs4-bridge/Dockerfile
-        sed -i.bak "s#image: thetorproject/obfs4-bridge:latest#build: .#" /root/docker-obfs4-bridge/docker-compose.yml
+    - name: Switch to Docker build on ARM Architecture file No1
+      ansible.builtin.replace:
+        path: /root/docker-obfs4-bridge/Dockerfile
+        regexp: "FROM debian:stable-slim"
+        replace: "FROM arm64v8/debian:stable-slim"
+        backup: true
+      when: ansible_architecture == "aarch64"
+      tags:
+        - update
+        - tor
+    - name: Switch to Docker build on ARM Architecture file No2
+      ansible.builtin.replace:
+        path: /root/docker-obfs4-bridge/docker-compose.yml
+        regexp: "image: thetorproject/obfs4-bridge:latest"
+        replace: "build: ."
+        backup: true
+      when: ansible_architecture == "aarch64"
+      tags:
+        - update
+        - tor
+    - name: Stop bridge
+      ansible.builtin.command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml down
+      register: docker_stopped
+      tags:
+        - update
+        - tor
+    - name: Remove old image
+      ansible.builtin.command: docker image rm docker-obfs4-bridge_obfs4-bridge
       when: ansible_architecture == "aarch64"
       tags:
         - update
         - tor
     - name: Build docker-compose project
-      command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml build
+      ansible.builtin.command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml build
       when: ansible_architecture == "aarch64"
       tags:
         - update
         - tor
     - name: Pull new docker image
-      command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml pull
+      ansible.builtin.command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml pull
       when: ansible_architecture == "x86_64"
       tags:
         - update
         - tor
     - name: Starting container
-      command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml up -d
+      ansible.builtin.command: docker-compose --env-file /root/docker-obfs4-bridge/.env --file /root/docker-obfs4-bridge/docker-compose.yml up -d
       register: out
       tags:
         - update
         - tor
+      changed_when: out == 0
     - name: Retrieving first run logs
-      command: docker container logs docker-obfs4-bridge-obfs4-bridge-1
+      ansible.builtin.command: docker container logs docker-obfs4-bridge-obfs4-bridge-1
       register: out
       tags:
         - update
         - tor
-    - debug: var=out.stdout_lines
+      changed_when: out == 0
+    - name: Debugging
+      ansible.builtin.debug:
+        var: out.stdout_lines
       tags:
         - update
         - tor


### PR DESCRIPTION
- added tags to tasks in `run_bridge.yml` to be able to just run those tasks
- changed git role to always reset (force=yes)
- added switch to either `docker-compose pull` or `docker-compose build` depending on the processor architecture